### PR TITLE
Update inworldz-core-base.sql to fix ServerFlags omission.

### DIFF
--- a/bin/inworldz-core-base.sql
+++ b/bin/inworldz-core-base.sql
@@ -1025,6 +1025,7 @@ CREATE TABLE `prims` (
   `CollisionSound` char(36) NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000',
   `CollisionSoundVolume` double NOT NULL DEFAULT '0',
   `LinkNumber` int(11) NOT NULL DEFAULT '0',
+  `ServerFlags` int(11) NOT NULL DEFAULT '0',	
   PRIMARY KEY (`UUID`),
   KEY `prims_regionuuid` (`RegionUUID`),
   KEY `prims_scenegroupid` (`SceneGroupID`)


### PR DESCRIPTION
Fixes hc-database.exe creating Database with missing "ServerFlags" column in prims table.

Change also made in inworldz-rdb-base.sql