### PR TITLE
Update inworldz-rdb-base.sql to fix ServerFlags column omission.

### DIFF
--- a/bin/inworldz-rdb-base.sql
+++ b/bin/inworldz-rdb-base.sql
@@ -211,6 +211,7 @@ CREATE TABLE `prims` (
   `ServerWeight` double DEFAULT '0',
   `StreamingCost` double DEFAULT '0',
   `KeyframeAnimation` blob,
+  `ServerFlags` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`UUID`),
   KEY `prims_regionuuid` (`RegionUUID`),
   KEY `prims_scenegroupid` (`SceneGroupID`)


### PR DESCRIPTION
Fixes hc-database.exe creating Database with missing "ServerFlags" column in prims table.

Change also made in inworldz-core-base.sql