### PR TITLE
Fixed to use the 4th place, where TT updates the revision with the date.

### DIFF
--- a/OpenSim/Framework/Servers/VersionInfo.tt
+++ b/OpenSim/Framework/Servers/VersionInfo.tt
@@ -65,7 +65,7 @@ namespace OpenSim
             {
                 Version ver = typeof(VersionInfo).Assembly.GetName().Version;
                 _version = String.Format("{0}.{1}.{2}", ver.Major, ver.Minor, ver.Build);
-                _revision = ver.Build.ToString();
+                _revision = ver.Revision.ToString();
             }
             return _revision;
         }


### PR DESCRIPTION
Matches the .tt file, and avoids 0.9.41.41 everywhere.