### PR TITLE
Added VSCode support, plus simplified CLI build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,8 +36,7 @@ before_build:
       $env:EDITION = "dotnet"
     }
 - cmd: IF EXIST runprebuild.bat runprebuild.bat
-- sh: if [ -x runprebuild.sh ]; then ./runprebuild.sh; fi
-- nuget restore Halcyon.sln
+- cmd: nuget restore Halcyon.sln
 
 build:
   parallel: true
@@ -52,13 +51,18 @@ for:
     only:
     - image: Ubuntu
   build_script:
-  - msbuild /p:DefineConstants="_MONO_CLI_FLAG_" Halcyon.sln
+  - ./build.sh
 
 after_build:
 - ps: |
     If (Test-Path "bin/OpenSim.Framework.Servers.dll") {
       $halcyon_version = (Get-ChildItem -Path bin/OpenSim.Framework.Servers.dll | % versioninfo).ProductVersion
-      Update-AppveyorBuild -Version "$halcyon_version-$env:APPVEYOR_BUILD_NUMBER"
+      Write-Output "Detected version: $halcyon_version"
+      Write-Output "AppVeyor build number: $env:APPVEYOR_BUILD_NUMBER"
+      $build_version = "$halcyon_version-$env:APPVEYOR_BUILD_NUMBER"
+      If ("$env:APPVEYOR_BUILD_VERSION" -ne "$build_version") {
+        Update-AppveyorBuild -Version "$build_version"
+      }
     }
 - ps: Rename-Item -Path bin -NewName halcyon-$env:APPVEYOR_BUILD_VERSION-$env:APPVEYOR_REPO_BRANCH-$env:EDITION
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ platform:
 - x64
 
 pull_requests:
-  do_not_increment_build_number: true
+  do_not_increment_build_number: false
 
 nuget:
   disable_publish_on_pr: true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch User Server",
+            "type": "mono",
+            "request": "launch",
+            "program": "${workspaceRoot}/bin/OpenSim.Grid.UserServer.exe",
+            "cwd": "${workspaceRoot}/bin"
+        },
+        {
+            "name": "Launch Messaging Server",
+            "type": "mono",
+            "request": "launch",
+            "program": "${workspaceRoot}/bin/OpenSim.Grid.MessagingServer.exe",
+            "cwd": "${workspaceRoot}/bin"
+        },
+        {
+            "name": "Launch Grid Server",
+            "type": "mono",
+            "request": "launch",
+            "program": "${workspaceRoot}/bin/OpenSim.Grid.GridServer.exe",
+            "cwd": "${workspaceRoot}/bin"
+        },
+        {
+            "name": "Launch Region Server",
+            "type": "mono",
+            "request": "launch",
+            "program": "${workspaceRoot}/bin/Halcyon.exe",
+            "cwd": "${workspaceRoot}/bin"
+        },
+        {
+            "name": "Attach",
+            "type": "mono",
+            "request": "attach",
+            "address": "localhost",
+            "port": 55555
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.insertFinalNewline": true,
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "linux": {
+                "command": "./build.sh"
+            },
+            "windows": {
+                "command": "./build.ps1"
+            },
+            "args": [
+                "/property:GenerateFullPaths=true",
+                "/t:build"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,7 @@
+If (Test-Path "runprebuild.bat") {
+    ./runprebuild.bat
+}
+
+nuget restore Halcyon.sln
+
+msbuild

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -x runprebuild.sh ]; then
+    ./runprebuild.sh
+fi
+
+nuget restore Halcyon.sln
+
+msbuild /p:DefineConstants="_MONO_CLI_FLAG_" Halcyon.sln


### PR DESCRIPTION
Makes things somewhat nicer on Linux.

Though it does mean that the build process is duplicated in a few locations: documentation, `build.sh`, `build.ps1`, and `appveyor.yml`.

I didn't make `appveyor.yml` use the new build command on Windows as I prefer to use the built-in command tooling when possible.