### PR TITLE
Trust manager tweaks

### DIFF
--- a/OpenSim/Framework/TrustManager.cs
+++ b/OpenSim/Framework/TrustManager.cs
@@ -100,8 +100,12 @@ namespace OpenSim.Framework
                 _goodIPMasks.Clear();
                 while ((line = file.ReadLine()) != null)
                 {
-                    _log.InfoFormat("[TRUSTMGR] Added whitelist IP {0}", line);
-                    _goodIPMasks.Add(line);
+                    line = line.Trim();
+                    if (!String.IsNullOrWhiteSpace(line))
+                    {
+                        _log.InfoFormat("[TRUSTMGR] Added whitelist IP {0}", line);
+                        _goodIPMasks.Add(line);
+                    }
                 }
             }
         }

--- a/OpenSim/Framework/TrustManager.cs
+++ b/OpenSim/Framework/TrustManager.cs
@@ -97,6 +97,7 @@ namespace OpenSim.Framework
             using (System.IO.StreamReader file = new System.IO.StreamReader(IP_TRUST_FILE))
             {
                 string line;
+                _goodIPMasks.Clear();
                 while ((line = file.ReadLine()) != null)
                 {
                     _log.InfoFormat("[TRUSTMGR] Added whitelist IP {0}", line);

--- a/OpenSim/Framework/TrustManager.cs
+++ b/OpenSim/Framework/TrustManager.cs
@@ -48,6 +48,7 @@ namespace OpenSim.Framework
 
         private object _lock = new object();
         private List<string> _goodIPMasks = new List<string>();
+        private bool _trustAll = false;
 
         private static readonly string[] DEFAULT_TRUSTED_NETWORKS = new string[] 
         {
@@ -81,7 +82,7 @@ namespace OpenSim.Framework
         {
             lock (_lock)
             {
-                _log.InfoFormat("[TRUSTMGR] Reloading trust lists");
+                _log.InfoFormat("[TRUSTMGR]: Reloading trust lists");
                 this.ReloadNetworkTrustList();
             }
         }
@@ -96,14 +97,24 @@ namespace OpenSim.Framework
             // Read the file and display it line by line.
             using (System.IO.StreamReader file = new System.IO.StreamReader(IP_TRUST_FILE))
             {
-                string line;
                 _goodIPMasks.Clear();
+                _trustAll = false;
+
+                string line;
                 while ((line = file.ReadLine()) != null)
                 {
                     line = line.Trim();
+                    if (line.Equals("*"))
+                    {
+                        _log.InfoFormat("[TRUSTMGR]: Enabling trust wildcard for all IPs.");
+                        _goodIPMasks.Clear();
+                        _trustAll = true;
+                        break;
+                    }
+
                     if (!String.IsNullOrWhiteSpace(line))
                     {
-                        _log.InfoFormat("[TRUSTMGR] Added whitelist IP {0}", line);
+                        _log.InfoFormat("[TRUSTMGR]: Added whitelist IP {0}", line);
                         _goodIPMasks.Add(line);
                     }
                 }
@@ -125,6 +136,7 @@ namespace OpenSim.Framework
         {
             lock (_lock)
             {
+                if (_trustAll) return true;
                 string addr = endPoint.Address.ToString();
                 foreach (string ipMask in _goodIPMasks)
                 {
@@ -142,6 +154,7 @@ namespace OpenSim.Framework
         {
             lock (_lock)
             {
+                if (_trustAll) return true;
                 foreach (string ipMask in _goodIPMasks)
                 {
                     if (peer.StartsWith(ipMask))

--- a/OpenSim/Grid/UserServer/UserServerCommandModule.cs
+++ b/OpenSim/Grid/UserServer/UserServerCommandModule.cs
@@ -132,6 +132,10 @@ namespace OpenSim.Grid.UserServer
             m_console.Commands.AddCommand("default", false, "default logins",
                                           "default logins [<filename>]",
                                           "Show or set the initial region locations for new users via a file of locations", HandleDefault);
+
+            m_console.Commands.AddCommand("base", false, "trust reload",
+                                          "trust reload",
+                                          "Reloads the trust configuration for the trust manager", HandleTrustReload);
         }
 
         #region Console Command Handlers
@@ -306,6 +310,11 @@ namespace OpenSim.Grid.UserServer
                     }
                 }
             }
+        }
+
+        private void HandleTrustReload(string module, string[] args)
+        {
+            TrustManager.Instance.ReloadTrustLists();
         }
 
         public void RunCommand(string module, string[] cmd)


### PR DESCRIPTION
* Provide the Halcyon region's `trust reload` command to User grid service too.
* Fixed TrustManager to allow changes and removals, not just additions (by clearing the list before running through the additions).
* Fixed to ignores lines in trustednetworks.txt that are only whitespace (rather than to treat a blank line as a wildcard IP).
* Add support for explicitly accepting any IP as trusted via adding `*` to the list in `trustednetworks.txt`.