### PR TITLE
Added ConsoleMode class and call to disable Quick Edit mode on consoles.

### DIFF
--- a/OpenSim/Framework/Console/CommandConsole.cs
+++ b/OpenSim/Framework/Console/CommandConsole.cs
@@ -710,7 +710,12 @@ namespace OpenSim.Framework.Console
                 "Help", false, "help", "help [<item>]",
                 "Display help on a particular command or on a list of commands in a category", Help);
 
-            ConsoleMode.DisableQuickEdit();
+            // Windows consoles have a Quick Edit mode that halts the process on a mouse click while the user interacts.
+            // We need to disable that unless the user does an Edit->Mark to select some text.
+            if (Util.IsWindows)
+            {
+                ConsoleMode.DisableQuickEdit();
+            }
         }
 
         private void Help(string module, string[] cmd)

--- a/OpenSim/Framework/Console/CommandConsole.cs
+++ b/OpenSim/Framework/Console/CommandConsole.cs
@@ -28,15 +28,7 @@
 using System;
 using System.Xml;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
-using log4net;
-using OpenSim.Framework;
 
 namespace OpenSim.Framework.Console
 {
@@ -717,6 +709,8 @@ namespace OpenSim.Framework.Console
             Commands.AddCommand(
                 "Help", false, "help", "help [<item>]",
                 "Display help on a particular command or on a list of commands in a category", Help);
+
+            ConsoleMode.DisableQuickEdit();
         }
 
         private void Help(string module, string[] cmd)

--- a/OpenSim/Framework/Console/ConsoleMode.cs
+++ b/OpenSim/Framework/Console/ConsoleMode.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace OpenSim.Framework.Console
+{
+    public static class ConsoleMode
+    {
+        const uint ENABLE_QUICK_EDIT = 0x0040;
+        const uint ENABLE_EXTENDED_FLAGS = 0x0080;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern IntPtr GetStdHandle(int nStdHandle);
+
+        [DllImport("kernel32.dll")]
+        static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+        [DllImport("kernel32.dll")]
+        static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+
+        private const int STDIN_HANDLE = -10;
+        internal static bool DisableQuickEdit()
+        {
+            IntPtr consoleHandle = GetStdHandle(STDIN_HANDLE);
+
+            uint consoleMode;
+            // get current console mode
+            if (!GetConsoleMode(consoleHandle, out consoleMode))
+                return false;
+
+            // setting QUICK_EDIT mode either way requires EXTENDED
+            consoleMode |= ENABLE_EXTENDED_FLAGS;
+            consoleMode &= ~ENABLE_QUICK_EDIT;
+            return SetConsoleMode(consoleHandle, consoleMode);
+        }
+    }
+}

--- a/OpenSim/Framework/Console/OpenSim.Framework.Console.csproj
+++ b/OpenSim/Framework/Console/OpenSim.Framework.Console.csproj
@@ -116,6 +116,7 @@
 	  <Compile Include="AssemblyInfo.cs">
 		<SubType>Code</SubType>
 	  </Compile>
+    <Compile Include="ConsoleMode.cs" />
 	  <Compile Include="CommandConsole.cs">
 		<SubType>Code</SubType>
 	  </Compile>


### PR DESCRIPTION
This PR resolves a very serious problem causing consoles (servers!) to _hang_ if someone merely clicked on the console with the mouse. (I thought this was already coded, years ago... it's like a change was lost somewhere.) This implementation is probably cleaner than any previous one anyway.

(This is a common complaint among server developers: see [this Stack Overflow](https://stackoverflow.com/questions/30418886/how-and-why-does-quickedit-mode-in-command-prompt-freeze-applications) article for a typical post.