### PR TITLE
Some cleanup

### DIFF
--- a/OpenSim/Framework/Util.cs
+++ b/OpenSim/Framework/Util.cs
@@ -2417,6 +2417,7 @@ namespace OpenSim.Framework
         /// Returns x/y min and max for a draw distance based region area around the given region location
         /// </summary>
         /// <param name="drawDistance">The draw distance we're checking</param>
+        /// <param name="maxRange">Maximum per-axis distance in number of regions</param>
         /// <param name="regionLocX">The X location of the current region</param>
         /// <param name="regionLocY">The Y location of the current region</param>
         /// <param name="xmin">Outputs the X minimum for the DD rectangle</param>
@@ -2435,14 +2436,8 @@ namespace OpenSim.Framework
 
             if (maxRange > 0)   // apply it
             {
-                if ((regionLocX - xmin) > maxRange)
-                    xmin = regionLocX - maxRange;
-                if ((regionLocY - ymin) > maxRange)
-                    ymin = regionLocY - maxRange;
-                if ((xmax - regionLocX) > maxRange)
-                    xmax = regionLocX + maxRange;
-                if ((ymax - regionLocY) > maxRange)
-                    ymax = regionLocY + maxRange;
+                xmin = Util.Clamp(xmin, regionLocX - maxRange, regionLocX + maxRange);
+                ymin = Util.Clamp(ymin, regionLocY - maxRange, regionLocY + maxRange);
             }
         }
 

--- a/OpenSim/Region/Framework/Scenes/AvatarRemotePresences.cs
+++ b/OpenSim/Region/Framework/Scenes/AvatarRemotePresences.cs
@@ -134,7 +134,7 @@ namespace OpenSim.Region.Framework.Scenes
                 //set up our initial connections to neighbors
                 //let the task run async in the background
                 const int CROSSING_RESYNC_DELAY = 500;
-                this.CalculateAndResyncNeighbors((uint)presence.DrawDistance, presence.ControllingClient.NeighborsRange, CROSSING_RESYNC_DELAY);
+                this.CalculateAndResyncNeighbors((uint)presence.DrawDistance, presence.ControllingClient.NeighborsRange, CROSSING_RESYNC_DELAY)?.Wait();
             }
         }
 
@@ -190,11 +190,11 @@ namespace OpenSim.Region.Framework.Scenes
             switch (changeType)
             {
                 case NeighborStateChangeType.NeighborUp:
-                    this.HandleNeighborUp(neighbor);
+                    this.HandleNeighborUp(neighbor)?.Wait();
                     break;
 
                 case NeighborStateChangeType.NeighborDown:
-                    this.HandleNeighborDown(neighbor);
+                    this.HandleNeighborDown(neighbor)?.Wait();
                     break;
             }
         }

--- a/OpenSim/Region/Framework/Scenes/AvatarRemotePresences.cs
+++ b/OpenSim/Region/Framework/Scenes/AvatarRemotePresences.cs
@@ -529,14 +529,13 @@ namespace OpenSim.Region.Framework.Scenes
         /// Resyncs the user with our view of the neighbors
         /// </summary>
         /// <param name="newDrawDistance">The new DD for the user</param>
+        /// <param name="maxRange">Maximum per-axis distance in number of regions</param>
         /// <param name="resyncDelay">Delay before executing the resync. We  delay on a region crossing because the viewer locks up sometimes when freeing memory</param>
         /// <returns></returns>
         private async Task CalculateAndResyncNeighbors(uint newDrawDistance, uint maxRange, int resyncDelay)
         {
-            uint xmin, xmax, ymin, ymax;
-
-            Util.GetDrawDistanceBasedRegionRectangle((uint)newDrawDistance, maxRange, _scene.RegionInfo.RegionLocX,
-                _scene.RegionInfo.RegionLocY, out xmin, out xmax, out ymin, out ymax);
+            Util.GetDrawDistanceBasedRegionRectangle(newDrawDistance, maxRange, _scene.RegionInfo.RegionLocX,
+                _scene.RegionInfo.RegionLocY, out uint xmin, out uint xmax, out uint ymin, out uint ymax);
 
             //get our current neighbor list
             List<SimpleRegionInfo> knownNeighborsList = _scene.SurroundingRegions.GetKnownNeighborsWithinClientDD(newDrawDistance, maxRange);

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -6050,7 +6050,7 @@ namespace OpenSim.Region.Framework.Scenes
             return this.WaitScenePresence(agentId, maxSpWait) != null;
         }
 
-        internal void CrossWalkingOrFlyingAgentToNewRegion(ScenePresence scenePresence, ulong neighborHandle, SimpleRegionInfo neighborInfo, Vector3 positionInNewRegion)
+        internal async Task CrossWalkingOrFlyingAgentToNewRegion(ScenePresence scenePresence, ulong neighborHandle, SimpleRegionInfo neighborInfo, Vector3 positionInNewRegion)
         {
             AvatarTransit.TransitArguments args = new AvatarTransit.TransitArguments
             {
@@ -6063,7 +6063,7 @@ namespace OpenSim.Region.Framework.Scenes
                 UserId = scenePresence.UUID,
             };
 
-            m_transitController.TryBeginTransit(args);
+            await m_transitController.TryBeginTransit(args);
         }
 
         internal bool AvatarIsInTransit(UUID uuid)

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -3707,25 +3707,30 @@ namespace OpenSim.Region.Framework.Scenes
             m_LastChildAgentUpdatePosition.Y = pos.Y;
             m_LastChildAgentUpdatePosition.Z = pos.Z;
 
-            ChildAgentDataUpdate cadu = new ChildAgentDataUpdate();
-            cadu.ActiveGroupID = UUID.Zero.Guid;
-            cadu.AgentID = UUID.Guid;
-            cadu.alwaysrun = m_setAlwaysRun;
-            cadu.AVHeight = m_avHeight;
-            sLLVector3 tempCameraCenter = new sLLVector3(new Vector3(m_CameraCenter.X, m_CameraCenter.Y, m_CameraCenter.Z));
-            cadu.cameraPosition = tempCameraCenter;
-            cadu.drawdistance = m_DrawDistance;
-            if (!this.IsBot)    // bots don't need IsGod checks
-                if (m_scene.Permissions?.IsGod(new UUID(cadu.AgentID)) ?? false)
-                    cadu.godlevel = m_godlevel;
-            cadu.GroupAccess = 0;
-            cadu.Position = new sLLVector3(pos);
-            cadu.regionHandle = m_scene.RegionInfo.RegionHandle;
-
             float multiplier = CalculateNeighborBandwidthMultiplier();
             //m_log.Info("[NeighborThrottle]: " + m_scene.GetInaccurateNeighborCount().ToString() + " - m: " + multiplier.ToString());
-            cadu.throttles = ControllingClient.GetThrottlesPacked(multiplier);
-            cadu.Velocity = new sLLVector3(Velocity);
+
+            ChildAgentDataUpdate cadu = new ChildAgentDataUpdate
+            {
+                ActiveGroupID = UUID.Zero.Guid,
+                AgentID = UUID.Guid,
+                alwaysrun = m_setAlwaysRun,
+                AVHeight = m_avHeight,
+                cameraPosition = new sLLVector3(new Vector3(m_CameraCenter.X, m_CameraCenter.Y, m_CameraCenter.Z)),
+                drawdistance = m_DrawDistance,
+                GroupAccess = 0,
+                Position = new sLLVector3(pos),
+                regionHandle = m_scene.RegionInfo.RegionHandle,
+                throttles = ControllingClient.GetThrottlesPacked(multiplier),
+                Velocity = new sLLVector3(Velocity),
+            };
+            if (!this.IsBot) // bots don't need IsGod checks
+            {
+                if (m_scene.Permissions?.IsGod(new UUID(cadu.AgentID)) ?? false)
+                {
+                    cadu.godlevel = m_godlevel;
+                }
+            }
 
             AgentPosition agentpos = new AgentPosition();
             agentpos.CopyFrom(cadu);

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -3289,7 +3289,7 @@ namespace OpenSim.Region.Framework.Scenes
                 }
 
                 // followed suggestion from mic bowman. reversed the two lines below.
-                CheckForBorderCrossing();
+                CheckForBorderCrossing()?.Wait();
                 CheckForSignificantMovement(); // sends update to the modules.
             }
         }
@@ -3759,7 +3759,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// <summary>
         /// Checks to see if the avatar is in range of a border and calls CrossToNewRegion
         /// </summary>
-        protected void CheckForBorderCrossing()
+        protected async Task CheckForBorderCrossing()
         {
             int neighbor = 0;
             Vector3 pos;
@@ -3853,7 +3853,7 @@ namespace OpenSim.Region.Framework.Scenes
                     pos2.X += fix[0];
                     pos2.Y += fix[1];
 
-                    CrossToNewRegion(neighborHandle, neighborInfo, pos2);
+                    await CrossToNewRegion(neighborHandle, neighborInfo, pos2);
                 }
             }
         }
@@ -3915,7 +3915,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// If the neighbor accepts, remove the agent's viewable avatar from this scene
         /// set them to a child agent.
         /// </summary>
-        protected void CrossToNewRegion(ulong neighborHandle, SimpleRegionInfo neighborInfo, Vector3 positionInNewRegion)
+        protected async Task CrossToNewRegion(ulong neighborHandle, SimpleRegionInfo neighborInfo, Vector3 positionInNewRegion)
         {
             ulong started = Util.GetLongTickCount();
 
@@ -3930,7 +3930,7 @@ namespace OpenSim.Region.Framework.Scenes
                 }
             }
 
-            m_scene.CrossWalkingOrFlyingAgentToNewRegion(this, neighborHandle, neighborInfo, positionInNewRegion);
+            await m_scene.CrossWalkingOrFlyingAgentToNewRegion(this, neighborHandle, neighborInfo, positionInNewRegion);
 
             m_log.InfoFormat("[SCENE]: Crossing for avatar took {0} ms for {1}.", Util.GetLongTickCount()-started, this.Name);
         }

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -1724,7 +1724,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public void UpdateForDrawDistanceChange()
         {
-            m_remotePresences.HandleDrawDistanceChanged((uint)m_DrawDistance);
+            m_remotePresences.HandleDrawDistanceChanged((uint)m_DrawDistance)?.Wait();
         }
 
         /// <summary>
@@ -1732,7 +1732,6 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         public void HandleAgentUpdate(IClientAPI remoteClient, AgentUpdateArgs agentData)
         {
-            bool recoverPhysActor = false;
             if (m_isChildAgent)
             {
                 //m_log.Warn("[CROSSING]: HandleAgentUpdate from child agent ignored "+agentData.AgentID.ToString());


### PR DESCRIPTION
While I was working on the unit tests trying to figure things out I refactored a few places in the tested code paths to understand them better and make sure they weren't the problem.  They weren't, but I decided I liked the result.

Should be mostly non-semantic, though I'm not 100% certain, especially in regard to the `?.Wait()` calls. Those lines were changed in this manner because the editor complained that they were async functions being called synchronously. Now they should still be synchronous in functionality but with a proper call to `Wait`. Some cases I propagated the async status up the call chain until I hit an API layer or where there were too many callers for my tastes.

When correctly merged with the unit tests PR #48, which isn't a clean merge, it still passes all the tests.  Whichever gets reviewed and merged first I'll rebase the other to clean it up.