### PR TITLE
Avoid reporting asset save errors, in the "already exists" case.

### DIFF
--- a/OpenSim/Framework/Communications/Cache/AssetCache.cs
+++ b/OpenSim/Framework/Communications/Cache/AssetCache.cs
@@ -310,8 +310,8 @@ namespace OpenSim.Framework.Communications.Cache
                 catch (AssetAlreadyExistsException e)
                 {
                     //Don't rethrow this exception. AssetServerExceptions thrown from here
-                    //will trigger a message on the client
-                    m_log.WarnFormat("[ASSET CACHE] Not storing asset that already exists: {0}", e.Message);
+                    // Let's not report this as a warning since this isn't a problem.
+                    // m_log.WarnFormat("[ASSET CACHE] Not storing asset that already exists: {0}", e.Message);
                 }
 
                 StatsManager.SimExtraStats.AddAssetWriteTime((long)(Util.GetLongTickCount() - startTime));

--- a/OpenSim/Framework/Communications/Cache/WHIPAssetClient.cs
+++ b/OpenSim/Framework/Communications/Cache/WHIPAssetClient.cs
@@ -354,10 +354,6 @@ namespace InWorldz.Whip.Client
                 //there is an error, log it, and then tell the caller we have no asset to give
                 if (!_loadingDefaultAssets)
                 {
-                    _log.ErrorFormat(
-                        "[WHIP.AssetClient]: Failure storing asset {0}" + Environment.NewLine + e.ToString()
-                        + Environment.NewLine, asset.FullID);
-
                     if (e.Message.Contains("already exists")) 
                     {
                         //this is hacky, but I dont want to edit the whip client this
@@ -366,6 +362,9 @@ namespace InWorldz.Whip.Client
                     }
                     else
                     {
+                        _log.ErrorFormat(
+                            "[WHIP.AssetClient]: Failure storing asset {0}" + Environment.NewLine + e.ToString()
+                            + Environment.NewLine, asset.FullID);
                         throw new AssetServerException(e.Message, e);
                     }
                 }


### PR DESCRIPTION
It is normal to have "asset already exists" cases. We get them when loading oars with assets, and also we get them on every region startup. It's not really an error to try to save the same asset with a specific ID again, so this PR moves the error report to the else case where we've already specifically handled the already exists error case. It also eliminates the second duplicate report for the same thing.