### PR TITLE
IW OARs part 2

### DIFF
--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
@@ -57,6 +57,8 @@ namespace OpenSim.Region.CoreModules.World.Archiver
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private static readonly String ASSET_CREATORS = "asset_creators";
 
+        private static readonly UUID LIBRARY_USER = new UUID("11111111-1111-0000-0000-000100bba000");
+
         private static readonly UUID DEFAULT_TERRAIN_1 = new UUID("b8d3965a-ad78-bf43-699b-bff8eca6c975");  // Terrain Dirt
         private static readonly UUID DEFAULT_TERRAIN_2 = new UUID("abb783e6-3e93-26c0-248a-247666855da3");  // Terrain Grass
         private static readonly UUID DEFAULT_TERRAIN_3 = new UUID("179cdabd-398a-9b6b-1391-4dc333ba321f");  // Terrain Mountain
@@ -127,7 +129,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             new Dictionary<UUID, bool>
             {
                 {UUID.Zero, true},
-                {new UUID("11111111-1111-0000-0000-000100bba000"), true} //the "mr opensim" user
+                {LIBRARY_USER, true} //the "Mr Halcyon" user
             };
 
         public ArchiveReadRequest(IConfigSource config, Scene scene, string loadPath, bool merge, Guid requestId, bool allowUserReassignment, bool skipErrorGroups, int debug)
@@ -246,6 +248,8 @@ namespace OpenSim.Region.CoreModules.World.Archiver
                             optInTable[uuid] = optContent;
                         }
                         reader.Close();
+                        // Add an exception for the standard Library "user".
+                        optInTable[LIBRARY_USER] = 2; // Library user opts-in FULL.
                     }
                 }
             }

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
@@ -600,13 +600,6 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             // First, replace the prim with a default prim.
             part.Shape = PrimitiveBaseShape.Default.Copy();
             ReplaceDescription(part, part.CreatorID);
-
-            // Now the object owner becomes the creator too of the replacement prim.
-            part.CreatorID = ownerID;
-            part.BaseMask = (uint)(PermissionMask.All | PermissionMask.Export);
-            part.OwnerMask = (uint)(PermissionMask.All | PermissionMask.Export);
-            part.NextOwnerMask = (uint)PermissionMask.All;
-            part.EveryoneMask = (uint)PermissionMask.None;
             // No need to replace textures since the whole prim was replaced.
             m_replacedPart++;
         }


### PR DESCRIPTION
I thought this was already pushed but it hadn't been yet. These were the final tweaks to assume an opt-in status for Library content, to avoid confusion by preserving the creator when substituting a prim, and the fix for the regression that broke mesh restores.