### PR TITLE
OARs part 3 - load filtered and OpenSim compatibility

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -5556,7 +5556,7 @@ namespace InWorldz.Phlox.Engine
                     if (SP != null) // user is here, always allow this
                         reply = "1";
                     else
-                    if ((userProfile == null) || (!userProfile.CurrentAgent.AgentOnline))
+                    if ((userProfile == null) || (userProfile.CurrentAgent == null) || (!userProfile.CurrentAgent.AgentOnline))
                     {
                         reply = "0";
                     }

--- a/InWorldz/InWorldz.Region.Data.Thoosa/Engines/InventoryObjectSerializer.cs
+++ b/InWorldz/InWorldz.Region.Data.Thoosa/Engines/InventoryObjectSerializer.cs
@@ -136,6 +136,26 @@ namespace InWorldz.Region.Data.Thoosa.Engines
         }
 
         /// <summary>
+        /// Returns whether or not this asset data represents a coalesced object
+        /// </summary>
+        /// <param name="bytes">A serialized object stream</param>
+        /// <returns></returns>
+        public bool IsValidCoalesced(byte[] bytes)
+        {
+            return CheckHeader(bytes, HeaderTestFlag.CheckValidCoalesced);
+        }
+
+        /// <summary>
+        /// Returns whether or not this asset data represents a single scene object group
+        /// </summary>
+        /// <param name="bytes">A serialized object stream</param>
+        /// <returns></returns>
+        public bool IsValidGroup(byte[] bytes)
+        {
+            return CheckHeader(bytes, HeaderTestFlag.CheckValidGroup);
+        }
+
+        /// <summary>
         /// Checks the given bytes to make sure the header is valid
         /// </summary>
         /// <param name="bytes"></param>

--- a/OpenSim/Base/OpenSim.cs
+++ b/OpenSim/Base/OpenSim.cs
@@ -272,8 +272,9 @@ namespace OpenSim
                                           "Scan's a region's data from an oar file, looking for the creator IDs of assets", ScanOarForCreators);
 
             m_console.Commands.AddCommand("region", false, "load filtered",
-                                          "load filtered <oar name> allowed_uuid [allowed_uuid ...]",
-                                          "Load a region's data from an OAR backup, filtering to owners/creators specifed", LoadFilteredOar);
+                                          "load filtered <oar_name> <allowed_uuid>|<allowed_uuid_filename> [...]",
+                                          "Load a region's data from an OAR file, filtering to owner/creator UUIDs specifed or in text file(s).", 
+                                          "If a filename is specified, it is one UUID with optional name per line. Can specify UUID or files in any mix.", LoadFilteredOar);
 
             m_console.Commands.AddCommand("region", false, "save oar",
                                           "save oar <oar name> <store_assets>",
@@ -1702,7 +1703,7 @@ namespace OpenSim
         protected void LoadFilteredOar(string module, string[] cmdparams)
         {
             if (cmdparams.Length < 4) {
-                m_console.Error("Usage: load filtered <oar name> allowed_uuid [allowed_uuid ...]");
+                m_console.Error("Usage: load filtered <oar_name> <allowed_uuid>|<allowed_uuid_file> [...]");
                 return;
             }
 

--- a/OpenSim/Base/OpenSim.cs
+++ b/OpenSim/Base/OpenSim.cs
@@ -267,9 +267,9 @@ namespace OpenSim
                                           "load oar [--allow-reassign] [--ignore-errors] <oar name>",
                                           "Load a region's data from OAR archive", LoadOar);
 
-            m_console.Commands.AddCommand("region", false, "scan iwoar",
-                                          "scan iwoar <oar name>",
-                                          "Scan's a region's data for creator IDs of assets from an InWorldz OAR backup", ScanIWOar);
+            m_console.Commands.AddCommand("region", false, "scan oar",
+                                          "scan oar <oar name>",
+                                          "Scan's a region's data from an oar file, looking for the creator IDs of assets", ScanOarForCreators);
 
             m_console.Commands.AddCommand("region", false, "load filtered",
                                           "load filtered <oar name> allowed_uuid [allowed_uuid ...]",
@@ -286,7 +286,7 @@ namespace OpenSim
 
             m_console.Commands.AddCommand("region", false, "saveportable oar",
                                           "saveportable oar <oar filename> [allowed_uuid allowed_uuid ...]",
-                                          "Save a region's data to an OAR archive with assets suitable for export from inworldz",
+                                          "Save a region's data to an OAR archive with assets suitable for export from the grid",
                                           "Store an archive [<store assets> 1 to save assets in the file or 0 to omit]", SavePortableOar);
 
             m_console.Commands.AddCommand("region", false, "saveexplicit oar",
@@ -1601,32 +1601,25 @@ namespace OpenSim
         }
 
         /// <summary>
-        /// Scan's a region's data for creator IDs of assets from an InWorldz OAR backup
-        /// scan iwoar [--save] oarname
+        /// Scan's a region's data from an oar file, looking for the creator IDs of assets
+        /// scan oar [--save] oarname
         /// </summary>
         /// <param name="cmdparams"></param>
-        protected void ScanIWOar(string module, string[] cmdparams)
+        protected void ScanOarForCreators(string module, string[] cmdparams)
         {
-            string fileName;
-            bool saveCreators;
-            if (cmdparams.Length > 3 && cmdparams[2] == "--save")
+            if (cmdparams.Length != 3)
             {
-                saveCreators = true;
-                fileName = cmdparams[3];
-            }
-            else
-            {
-                saveCreators = false;
-                fileName = cmdparams[2];
+                m_console.Error("Usage: scan oar <filename>");
+                return;
             }
 
             try
             {
-                m_sceneManager.ScanSceneForCreators(fileName);
+                m_sceneManager.ScanSceneForCreators(cmdparams[2]);
             }
             catch (FileNotFoundException)
             {
-                m_console.Error("Specified oar not found. Usage: load oar <filename>");
+                m_console.Error("Specified oar not found. Usage: scan oar <filename>");
             }
         }
 

--- a/OpenSim/Framework/Serialization/ArchiveConstants.cs
+++ b/OpenSim/Framework/Serialization/ArchiveConstants.cs
@@ -41,6 +41,12 @@ namespace OpenSim.Framework.Serialization
         public const string CONTROL_FILE_PATH = "archive.xml";
 
         /// <value>
+        /// The location of the user list file.
+        /// This file identifies all owner and creator IDs referenced in a region.
+        /// </value>
+        public const string USERLIST_FILE_PATH = "userlist.txt";
+
+        /// <value>
         /// Path for the assets held in an archive
         /// </value>
         public const string ASSETS_PATH = "assets/";

--- a/OpenSim/Framework/TaskInventoryDictionary.cs
+++ b/OpenSim/Framework/TaskInventoryDictionary.cs
@@ -118,11 +118,14 @@ namespace OpenSim.Framework
         // see IXmlSerializable
         public void WriteXml(XmlWriter writer)
         {
+            XmlSerializerNamespaces ns = new XmlSerializerNamespaces();
+            ns.Add("", "");
+
             lock (this)
             {
                 foreach (TaskInventoryItem item in Values)
                 {
-                    tiiSerializer.Serialize(writer, item);
+                    tiiSerializer.Serialize(writer, item, ns);
                 }
             }
 

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
@@ -459,7 +459,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             SceneObjectGroup grp;
 
             if (m_inventorySerializer == null) return null;
-            if (m_inventorySerializer.CanDeserialize(bytes))
+            if (m_inventorySerializer.IsValidGroup(bytes))
             {
                 grp = m_inventorySerializer.DeserializeGroupFromInventoryBytes(bytes);
             }

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
@@ -122,6 +122,9 @@ namespace OpenSim.Region.CoreModules.World.Archiver
         int m_scannedItems = 0;
         int m_debugOars = 0;
 
+        // false if we assume prim creator is creator of assets on prims, or has license to use, or will filter.
+        bool m_filterPrimAssets = false;    // false==include prim assets like textures
+
         /// <summary>
         /// Used to cache lookups for valid uuids.
         /// </summary>
@@ -631,6 +634,8 @@ namespace OpenSim.Region.CoreModules.World.Archiver
 
         private bool FilterPrimTexturesByCreator(SceneObjectPart part, UUID ownerID)
         {
+            if (!m_filterPrimAssets) return false;
+
             bool filtered = false;
 
             int basicSculptType = part.Shape.SculptType & (byte)0x3F;
@@ -688,6 +693,8 @@ namespace OpenSim.Region.CoreModules.World.Archiver
 
         private bool FilterOtherPrimAssetsByCreator(SceneObjectPart part, UUID ownerID)
         {
+            if (!m_filterPrimAssets) return false;
+
             bool filtered = false;
             if (part.Sound != UUID.Zero)
             {

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
@@ -964,7 +964,10 @@ namespace OpenSim.Region.CoreModules.World.Archiver
 
             if (allowedUUIDs != null)
             {
+                // Adopt this whitelist for filtering a load.
                 m_allowedUUIDs = allowedUUIDs;
+                // Also include the LIBRARY_USER in the whitelist.
+                m_allowedUUIDs.Add(LIBRARY_USER);
                 // Now a normal filtered load.
                 m_assetCreators = GetAssetCreators();
             }

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveWriteRequestExecution.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveWriteRequestExecution.cs
@@ -114,7 +114,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
 
                 Vector3 position = sceneObject.AbsolutePosition;
 
-                string serializedObject = m_serializer.SaveGroupToXml2(sceneObject);
+                string serializedObject = m_serializer.SaveGroupToOriginalXml(sceneObject);
                 string filename
                     = string.Format(
                         "{0}{1}_{2:000}-{3:000}-{4:000}__{5}.xml",

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveWriteRequestPreparation.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveWriteRequestPreparation.cs
@@ -225,7 +225,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             m_log.InfoFormat("[ARCHIVER]: Added control file to archive.");
 
             new AssetsRequest(
-                new AssetsArchiver(archiveWriter), assetUuids.Keys, 
+                new AssetsArchiver(archiveWriter, m_scene), assetUuids.Keys, 
                 m_scene.CommsManager.AssetCache, awre.ReceivedAllAssets).Execute();
         }
 

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveWriteRequestPreparation.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveWriteRequestPreparation.cs
@@ -30,13 +30,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
-using System.Text.RegularExpressions;
-using System.Threading;
+using System.Xml;
 using log4net;
 using OpenMetaverse;
 using OpenSim.Framework;
 using OpenSim.Framework.Serialization;
-using OpenSim.Region.CoreModules.World.Terrain;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Data;
@@ -220,8 +218,12 @@ namespace OpenSim.Region.CoreModules.World.Archiver
                     m_scene.RequestModuleInterface<IRegionSerializerModule>(),
                     m_scene,
                     archiveWriter,
-                    m_requestId);           
-            
+                    m_requestId);
+
+            // Write out control file first
+            archiveWriter.WriteFile(ArchiveConstants.CONTROL_FILE_PATH, awre.CreateControlFile(assetUuids.Count > 0));
+            m_log.InfoFormat("[ARCHIVER]: Added control file to archive.");
+
             new AssetsRequest(
                 new AssetsArchiver(archiveWriter), assetUuids.Keys, 
                 m_scene.CommsManager.AssetCache, awre.ReceivedAllAssets).Execute();

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiverModule.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiverModule.cs
@@ -114,26 +114,26 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             new ArchiveReadRequest(m_config, m_scene, loadPath, false, Guid.Empty, false, true, m_debug).ScanArchiveForAssetCreatorIDs();
         }
 
-        public void DearchiveRegion(string loadPath, bool allowUserReassignment, bool skipErrorGroups, string optionsTable)
+        public void DearchiveRegion(string loadPath, bool allowUserReassignment, bool skipErrorGroups, HashSet<UUID> allowedUUIDs)
         {
-            DearchiveRegion(loadPath, false, Guid.Empty, allowUserReassignment, skipErrorGroups, optionsTable);
+            DearchiveRegion(loadPath, false, Guid.Empty, allowUserReassignment, skipErrorGroups, allowedUUIDs);
         }
 
-        public void DearchiveRegion(string loadPath, bool merge, Guid requestId, bool allowUserReassignment, bool skipErrorGroups, string optionsTable)
+        public void DearchiveRegion(string loadPath, bool merge, Guid requestId, bool allowUserReassignment, bool skipErrorGroups, HashSet<UUID> allowedUUIDs)
         {
             m_log.InfoFormat("[ARCHIVER]: Loading archive to region {0} from {1}", m_scene.RegionInfo.RegionName, loadPath);
 
-            new ArchiveReadRequest(m_config, m_scene, loadPath, merge, requestId, allowUserReassignment, skipErrorGroups, m_debug).DearchiveRegion(optionsTable);
+            new ArchiveReadRequest(m_config, m_scene, loadPath, merge, requestId, allowUserReassignment, skipErrorGroups, m_debug).DearchiveRegion(allowedUUIDs);
         }
 
-        public void DearchiveRegion(Stream loadStream, bool allowUserReassignment, bool skipErrorGroups, string optionsTable)
+        public void DearchiveRegion(Stream loadStream, bool allowUserReassignment, bool skipErrorGroups, HashSet<UUID> allowedUUIDs)
         {
-            DearchiveRegion(loadStream, false, Guid.Empty, allowUserReassignment, skipErrorGroups, optionsTable);
+            DearchiveRegion(loadStream, false, Guid.Empty, allowUserReassignment, skipErrorGroups, allowedUUIDs);
         }
 
-        public void DearchiveRegion(Stream loadStream, bool merge, Guid requestId, bool allowUserReassignment, bool skipErrorGroups, string optionsTable)
+        public void DearchiveRegion(Stream loadStream, bool merge, Guid requestId, bool allowUserReassignment, bool skipErrorGroups, HashSet<UUID> allowedUUIDs)
         {
-            new ArchiveReadRequest(m_config, m_scene, loadStream, merge, requestId, allowUserReassignment, skipErrorGroups, m_debug).DearchiveRegion(optionsTable);
+            new ArchiveReadRequest(m_config, m_scene, loadStream, merge, requestId, allowUserReassignment, skipErrorGroups, m_debug).DearchiveRegion(allowedUUIDs);
         }        
     }
 }

--- a/OpenSim/Region/CoreModules/World/Archiver/AssetsArchiver.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/AssetsArchiver.cs
@@ -156,7 +156,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
 
             // Check for Thoosa Inventory object and decode to XML if necessary for Archive.
             string xmlData;
-            if ((m_inventorySerializer != null) && (m_inventorySerializer.CanDeserialize(asset.Data)))
+            if ((asset.Type == (sbyte)AssetType.Object) && (m_inventorySerializer != null) && (m_inventorySerializer.CanDeserialize(asset.Data)))
             {
                 if (m_inventorySerializer.IsValidCoalesced(asset.Data))
                 {
@@ -174,17 +174,19 @@ namespace OpenSim.Region.CoreModules.World.Archiver
                     SceneObjectGroup grp = m_inventorySerializer.DeserializeGroupFromInventoryBytes(asset.Data);
                     xmlData = m_serializer.SaveGroupToOriginalXml(grp);
                 }
-                else return;
+                else return;    // can't pass the CanDeserialize test above, but makes the compiler happy
+                // Now write out the XML format asset
+                m_archiveWriter.WriteFile(
+                    ArchiveConstants.ASSETS_PATH + asset.FullID.ToString() + extension,
+                    xmlData);
             }
             else
             {
-                xmlData = Utils.BytesToString(asset.Data);
+                // Now write out the same (raw) asset unchanged.
+                m_archiveWriter.WriteFile(
+                    ArchiveConstants.ASSETS_PATH + asset.FullID.ToString() + extension,
+                    asset.Data);
             }
-
-            m_archiveWriter.WriteFile(
-                ArchiveConstants.ASSETS_PATH + asset.FullID.ToString() + extension,
-                xmlData);
-
             m_assetsWritten++;
 
             if (m_assetsWritten % LOG_ASSET_LOAD_NOTIFICATION_INTERVAL == 0)

--- a/OpenSim/Region/CoreModules/World/Serializer/SerializerModule.cs
+++ b/OpenSim/Region/CoreModules/World/Serializer/SerializerModule.cs
@@ -133,6 +133,11 @@ namespace OpenSim.Region.CoreModules.World.Serializer
             return SceneXmlLoader.SaveGroupToXml2(grp);
         }
 
+        public string SaveGroupToOriginalXml(SceneObjectGroup grp)
+        {
+            return SceneXmlLoader.SaveGroupToOriginalXml(grp);
+        }
+        
         public void SavePrimListToXml2(List<EntityBase> entityList, string fileName)
         {
             SceneXmlLoader.SavePrimListToXml2(entityList, fileName);

--- a/OpenSim/Region/Framework/Interfaces/IRegionArchiverModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IRegionArchiverModule.cs
@@ -95,7 +95,7 @@ namespace OpenSim.Region.Framework.Interfaces
         /// If you want notification of when it has completed then subscribe to the EventManager.OnOarFileLoaded event.
         /// 
         /// <param name="loadPath"></param>
-        void DearchiveRegion(string loadPath, bool allowUserReassignment, bool skipErrorGroups, string optionsTable);
+        void DearchiveRegion(string loadPath, bool allowUserReassignment, bool skipErrorGroups, HashSet<UUID> allowedUUIDs);
         
         /// <summary>
         /// Dearchive the given region archive.  This replaces the existing scene.
@@ -109,7 +109,7 @@ namespace OpenSim.Region.Framework.Interfaces
         /// settings in the archive will be ignored.
         /// </param>
         /// <param name="requestId">If supplied, this request Id is later returned in the saved event</param>
-        void DearchiveRegion(string loadPath, bool merge, Guid requestId, bool allowUserReassignment, bool skipErrorGroups, string optionsTable);
+        void DearchiveRegion(string loadPath, bool merge, Guid requestId, bool allowUserReassignment, bool skipErrorGroups, HashSet<UUID> allowedUUIDs);
         
         /// <summary>
         /// Dearchive a region from a stream.  This replaces the existing scene. 
@@ -118,7 +118,7 @@ namespace OpenSim.Region.Framework.Interfaces
         /// If you want notification of when it has completed then subscribe to the EventManager.OnOarFileLoaded event.
         /// 
         /// <param name="loadStream"></param>
-        void DearchiveRegion(Stream loadStream, bool allowUserReassignment, bool skipErrorGroups, string optionsTable);
+        void DearchiveRegion(Stream loadStream, bool allowUserReassignment, bool skipErrorGroups, HashSet<UUID> allowedUUIDs);
         
         /// <summary>
         /// Dearchive a region from a stream.  This replaces the existing scene.
@@ -132,7 +132,7 @@ namespace OpenSim.Region.Framework.Interfaces
         /// settings in the archive will be ignored.
         /// </param>    
         /// <param name="requestId">If supplied, this request Id is later returned in the saved event</param>
-        void DearchiveRegion(Stream loadStream, bool merge, Guid requestId, bool allowUserReassignment, bool skipErrorGroups, string optionsTable);
+        void DearchiveRegion(Stream loadStream, bool merge, Guid requestId, bool allowUserReassignment, bool skipErrorGroups, HashSet<UUID> allowedUUIDs);
 
         /// <summary>
         /// Scans the objects in an archive to try to find creator IDs for asset (even if the assets are not present).

--- a/OpenSim/Region/Framework/Interfaces/IRegionSerializerModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IRegionSerializerModule.cs
@@ -118,5 +118,12 @@ namespace OpenSim.Region.Framework.Interfaces
         /// <param name="grp"></param>
         /// <returns></returns>
         string SaveGroupToXml2(SceneObjectGroup grp);
+
+        /// <summary>
+        /// Serialize an individual scene object into the original xml (xml1) format
+        /// </summary>
+        /// <param name="grp"></param>
+        /// <returns></returns>
+        string SaveGroupToOriginalXml(SceneObjectGroup grp);        
     }
 }

--- a/OpenSim/Region/Framework/Scenes/SceneManager.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneManager.cs
@@ -289,11 +289,11 @@ namespace OpenSim.Region.Framework.Scenes
         /// their assets to the asset service.
         /// </summary>
         /// <param name="filename"></param>
-        public void LoadArchiveToCurrentScene(string filename, bool allowUserReassignment, bool ignoreErrors, string optionsTable)
+        public void LoadArchiveToCurrentScene(string filename, bool allowUserReassignment, bool ignoreErrors, HashSet<UUID> allowedUUIDs)
         {
             IRegionArchiverModule archiver = CurrentOrFirstScene.RequestModuleInterface<IRegionArchiverModule>();
             if (archiver != null)            
-                archiver.DearchiveRegion(filename, allowUserReassignment, ignoreErrors, optionsTable);
+                archiver.DearchiveRegion(filename, allowUserReassignment, ignoreErrors, allowedUUIDs);
         }
 
         public string SaveCurrentSceneMapToXmlString()

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -4252,7 +4252,10 @@ namespace OpenSim.Region.Framework.Scenes
         /// <param name="xmlWriter"></param>
         public void ToXml(XmlWriter xmlWriter)
         {
-            serializer.Serialize(xmlWriter, this);
+            //Create our own namespaces for the output and add an empty namespace
+            XmlSerializerNamespaces ns = new XmlSerializerNamespaces();
+            ns.Add("", "");
+            serializer.Serialize(xmlWriter, this, ns);
         }
 
         public void TriggerScriptChangedEvent(Changed val)

--- a/OpenSim/Region/Framework/Scenes/Serialization/CoalescedSceneObjectSerializer.cs
+++ b/OpenSim/Region/Framework/Scenes/Serialization/CoalescedSceneObjectSerializer.cs
@@ -41,7 +41,7 @@ using System.Collections.Generic;
 
 namespace OpenSim.Region.Framework.Scenes.Serialization
 {
-    class CoalescedSceneObjectSerializer
+    public class CoalescedSceneObjectSerializer
     {
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 

--- a/OpenSim/Region/Framework/Scenes/Serialization/IInventoryObjectSerializer.cs
+++ b/OpenSim/Region/Framework/Scenes/Serialization/IInventoryObjectSerializer.cs
@@ -48,6 +48,20 @@ namespace OpenSim.Region.Framework.Scenes.Serialization
         bool CanDeserialize(byte[] bytes);
 
         /// <summary>
+        /// Returns whether or not this asset data represents a coalesced object
+        /// </summary>
+        /// <param name="bytes">A serialized object stream</param>
+        /// <returns></returns>
+        bool IsValidCoalesced(byte[] bytes);
+
+        /// <summary>
+        /// Returns whether or not this asset data represents a single scene object group
+        /// </summary>
+        /// <param name="bytes">A serialized object stream</param>
+        /// <returns></returns>
+        bool IsValidGroup(byte[] bytes);
+
+        /// <summary>
         /// Serializes a SOG to bytes that can then be deserialized and restored later
         /// </summary>
         /// <param name="group"></param>

--- a/OpenSim/Region/Framework/Scenes/Serialization/SceneObjectSerializer.cs
+++ b/OpenSim/Region/Framework/Scenes/Serialization/SceneObjectSerializer.cs
@@ -178,7 +178,7 @@ namespace OpenSim.Region.Framework.Scenes.Serialization
             catch (Exception e)
             {
                 m_log.ErrorFormat(
-                    "[SERIALIZER]: Deserialization of xml failed with {0}.", e);
+                    "[SERIALIZER]: Deserialization of xml1 failed with {0}.", e);
             }
             return null;
         }      
@@ -199,7 +199,18 @@ namespace OpenSim.Region.Framework.Scenes.Serialization
 
                 return sw.ToString();
             }
-        }                
+        }
+
+        /// <summary>
+        /// Serialize a scene object to the 'xml2' format.
+        /// </summary>
+        /// <param name="sceneObject"></param>
+        /// <returns></returns>               
+        public static string ToOriginalXmlFormat(SceneObjectGroup sceneObject, bool stopScripts)
+        {
+            StopScriptReason reason = stopScripts ? StopScriptReason.Derez : StopScriptReason.None;
+            return ToOriginalXmlFormat(sceneObject, reason);
+        }
 
         /// <summary>
         /// Serialize a scene object to the original xml format
@@ -228,7 +239,7 @@ namespace OpenSim.Region.Framework.Scenes.Serialization
             }
 
             writer.WriteEndElement(); // OtherParts
-            sceneObject.SaveScriptedState(writer, stopScriptReason);
+            // sceneObject.SaveScriptedState(writer, stopScriptReason);
             writer.WriteEndElement(); // SceneObjectGroup
 
             //m_log.DebugFormat("[SERIALIZER]: Finished serialization of SOG {0}, {1}ms", Name, System.Environment.TickCount - time);
@@ -294,7 +305,7 @@ namespace OpenSim.Region.Framework.Scenes.Serialization
             }
             catch (Exception e)
             {
-                m_log.ErrorFormat("[SERIALIZER]: Deserialization of xml failed with {0}.", e);
+                m_log.ErrorFormat("[SERIALIZER]: Deserialization of xml2 failed with {0}.", e);
             }
             return null;
         }         

--- a/OpenSim/Region/Framework/Scenes/Serialization/SceneXmlLoader.cs
+++ b/OpenSim/Region/Framework/Scenes/Serialization/SceneXmlLoader.cs
@@ -105,6 +105,11 @@ namespace OpenSim.Region.Framework.Scenes.Serialization
             return SceneObjectSerializer.ToXml2Format(grp, false);
         }
 
+        public static string SaveGroupToOriginalXml(SceneObjectGroup grp)
+        {
+            return SceneObjectSerializer.ToOriginalXmlFormat(grp, false);
+        }
+
         public static SceneObjectGroup DeserializeGroupFromXml2(string xmlString)
         {
             XmlDocument doc = new XmlDocument();

--- a/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
+++ b/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
@@ -175,14 +175,13 @@ namespace OpenSim.Region.Framework.Scenes
                     {
                         //m_log.DebugFormat("[ARCHIVER]: Analysing item asset type {0}", tii.Type);
 
-                        if (!assetUuids.ContainsKey(tii.AssetID))
+                        if ((tii.AssetID != UUID.Zero) && (!assetUuids.ContainsKey(tii.AssetID)))
                             GatherAssetUuids(tii.AssetID, (AssetType)tii.Type, assetUuids);
                     }
                 }
                 catch (Exception e)
                 {
                     m_log.ErrorFormat("[ASSET GATHERER]: Failed to get part - {0}", e);
-                    m_log.DebugFormat("[ASSET GATHERER]: Texture entry length for prim was {0} (min is 46)", part.Shape.TextureEntryBytes.Length);
                 }
             }
         }


### PR DESCRIPTION
This update removes the InWorldz-specific code for OAR file handling. It replaces the `load iwoar` command with a more grid-neutral `load filtered` command which accepts a space-separated whitelist of user UUIDs on the console command line, e.g.:
`load filtered myregion.oar 9d8cb15f-4b8a-4c08-ab79-6a4a85baf45e f5b19586-6846-4611-844d-16607093e184 7e050d79-1b82-4d2d-b7f5-6602b04d43eb`
It also replaces the strict texture creator checking with the less strict (more SL- and OpenSim-compatible) concept of textures on a prim.  It still substitutes both prims and Contents items with replacement plywood boxes or null assets, if the owner or creator are not both in the whitelist of allowed users.  It also still tries to use the `asset_creators` table if present, and the `scan iwoar` command still exists to populate that table, but has been renamed to `scan oar` since that part is not IW-specific.

The last commit changes OAR saves to include an OpenSim OAR 0.8 format-compatible control file in the archive, and ensures it is first (as per the OpenSim requirement).