### PR TITLE
Whitelisted items

### DIFF
--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
@@ -710,6 +710,9 @@ namespace OpenSim.Region.CoreModules.World.Archiver
         {
             bool filtered = false;
 
+            if (isWhitelistedObject(part))
+                return false;
+
             if (m_allowUserReassignment)
             {
                 if (part.OwnerID != ownerID)
@@ -823,10 +826,45 @@ namespace OpenSim.Region.CoreModules.World.Archiver
         }
 
         // Special-case overrides for common items that should be allowed but are not normally allowed by creator or owner
+        private UUID ZAUBER = new UUID("7b772b49-0dde-4e08-a8d7-6c26e09a6842");
+        const uint FULL_PERM = (uint)(PermissionMask.Copy | PermissionMask.Transfer | PermissionMask.Modify);
+        private bool isFullPerm(uint perms)
+        {
+            return ((perms & FULL_PERM) == FULL_PERM);
+        }
         private bool isWhitelistedItem(TaskInventoryItem item)
         {
             if (item.Name.StartsWith("LiteRezzer", StringComparison.InvariantCultureIgnoreCase))
                 return true;
+
+            if (item.CreatorID == ZAUBER)
+            {
+                if (item.Name.ToUpper().Contains("OPTI"))
+                    return true;
+                if (item.Description.ToUpper().Contains("OPTI"))
+                    return true;
+                if (item.Name.ToUpper().Contains("SORTER") && isFullPerm(item.CurrentPermissions))
+                    return true;
+            }
+
+            // No other special cases.
+            return false;
+        }
+
+        private bool isWhitelistedObject(SceneObjectPart part)
+        {
+            if (part.Name.StartsWith("LiteRezzer", StringComparison.InvariantCultureIgnoreCase))
+                return true;
+
+            if (part.CreatorID == ZAUBER)
+            {
+                if (part.Name.ToUpper().Contains("OPTI"))
+                    return true;
+                if (part.Description.ToUpper().Contains("OPTI"))
+                    return true;
+                if (part.ParentGroup.Name.ToUpper().Contains("SORTER") && isFullPerm(part.ParentGroup.GetEffectivePermissions(false)))
+                    return true;
+            }
 
             // No other special cases.
             return false;

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
@@ -822,6 +822,16 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             return filtered;
         }
 
+        // Special-case overrides for common items that should be allowed but are not normally allowed by creator or owner
+        private bool isWhitelistedItem(TaskInventoryItem item)
+        {
+            if (item.Name.StartsWith("LiteRezzer", StringComparison.InvariantCultureIgnoreCase))
+                return true;
+
+            // No other special cases.
+            return false;
+        }
+
         // depth==0 when it's the top-level object (no need to reserialize changes as asset)
         private bool FilterContents(SceneObjectPart part, UUID ownerID, int depth)
         {
@@ -866,6 +876,13 @@ namespace OpenSim.Region.CoreModules.World.Archiver
                     {
                         if (m_debugOars >= 2)
                             m_log.InfoFormat("[ARCHIVER]: Item '{0}' in part '{1}' has owner {2} matching creator.", item.Name, part.Name, item.OwnerID);
+                        m_keptItem++;
+                    }
+                    else
+                    if (isWhitelistedItem(item))
+                    {
+                        if (m_debugOars >= 2)
+                            m_log.InfoFormat("[ARCHIVER]: Item '{0}' in part '{1}' by creator {2} is a whitelisted item.", item.Name, part.Name, item.CreatorID);
                         m_keptItem++;
                     }
                     else

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveReadRequest.cs
@@ -841,6 +841,8 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             {
                 if (item.Name.ToUpper().Contains("OPTI"))
                     return true;
+                if (item.Name.ToLower().Trim().Equals("window beam"))
+                    return true;
                 if (item.Description.ToUpper().Contains("OPTI"))
                     return true;
                 if (item.Name.ToUpper().Contains("SORTER") && isFullPerm(item.CurrentPermissions))

--- a/OpenSim/Region/CoreModules/World/Archiver/ArchiveWriteRequestExecution.cs
+++ b/OpenSim/Region/CoreModules/World/Archiver/ArchiveWriteRequestExecution.cs
@@ -80,10 +80,12 @@ namespace OpenSim.Region.CoreModules.World.Archiver
         protected internal void ReceivedAllAssets(
             ICollection<UUID> assetsFoundUuids, ICollection<UUID> assetsNotFoundUuids)
         {
+            /*
             foreach (UUID uuid in assetsNotFoundUuids)
             {
                 m_log.DebugFormat("[ARCHIVER]: Could not find asset {0}", uuid);
             }
+            */
 
             m_log.InfoFormat(
                 "[ARCHIVER]: Received {0} of {1} assets requested",

--- a/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
+++ b/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
@@ -174,9 +174,15 @@ namespace OpenSim.Region.Framework.Scenes
                     foreach (TaskInventoryItem tii in taskDictionary.Values)
                     {
                         //m_log.DebugFormat("[ARCHIVER]: Analysing item asset type {0}", tii.Type);
-
-                        if ((tii.AssetID != UUID.Zero) && (!assetUuids.ContainsKey(tii.AssetID)))
-                            GatherAssetUuids(tii.AssetID, (AssetType)tii.Type, assetUuids);
+                        try
+                        {
+                            if ((tii.AssetID != UUID.Zero) && (!assetUuids.ContainsKey(tii.AssetID)))
+                                GatherAssetUuids(tii.AssetID, (AssetType)tii.Type, assetUuids);
+                        }
+                        catch (Exception e)
+                        {
+                            // can't fetch UUIDs from this item, catch the error and move on to the next.
+                        }
                     }
                 }
                 catch (Exception e)
@@ -263,6 +269,8 @@ namespace OpenSim.Region.Framework.Scenes
         {
             AssetBase assetBase = GetAsset(wearableAssetUuid);
             //m_log.Debug(new System.Text.ASCIIEncoding().GetString(bodypartAsset.Data));
+            if (assetBase == null) return;  // there are no UUIDs in this to find.
+
             OpenMetaverse.Assets.AssetWearable wearableAsset 
                 = new OpenMetaverse.Assets.AssetBodypart(wearableAssetUuid, assetBase.Data);
             wearableAsset.Decode();


### PR DESCRIPTION
My intention with this fork was for it to be specific to InWorldz but it does provide good examples of how to whitelist objects independent of the normal (owner+creator) concerns for whitelist in `load filtered`. I've decided we should probably merge this into `master` since it really the only IW-specific code there is the `IsWhitelistedObject` function, but this code should be completely harmless and demonstrates where to insert such exception cases in any future filtering.

However, if it is felt that this branch should not be merged, then there are two commits with a straight fixes for the master, the bottom two: https://github.com/HalcyonGrid/halcyon/commit/bac40ba343af091d3fe3947e26997ce29e5584a3 and https://github.com/HalcyonGrid/halcyon/commit/c62e15b090f6cd53a3324235147d4bebfe8ef675 which can either be cherrypicked or I can do another branch which only has those two commits.