### PR TITLE
Several fixes including SL compatibility with llGetObjectDetails for OPT_OTHER

### DIFF
--- a/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
+++ b/InWorldz/InWorldz.Phlox.Engine/LSLSystemAPI.cs
@@ -14321,7 +14321,10 @@ namespace InWorldz.Phlox.Engine
                                 ret.Add(part.AttachmentPoint);
                                 break;
                             case ScriptBaseClass.OBJECT_PATHFINDING_TYPE:
-                                ret.Add(ScriptBaseClass.OPT_LEGACY_LINKSET);
+                                if (part.IsLindenPlant())
+                                    ret.Add(ScriptBaseClass.OPT_OTHER);
+                                else
+                                    ret.Add(ScriptBaseClass.OPT_LEGACY_LINKSET);
                                 break;
                             case ScriptBaseClass.OBJECT_PHYSICS:
                                 if ((part.GetEffectiveObjectFlags() & PrimFlags.Physics) == PrimFlags.Physics)

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -913,11 +913,12 @@ namespace OpenSim.Region.Framework.Scenes
             if (AttachmentPt == 0)
             {
                 m_log.WarnFormat("[SCENE]: AttachmentPoint still ZERO and about to attach! PrepareForRezAsAttachment not called?");
-                group.RootPart.Shape.State = (byte)AttachmentPoint.LeftHand;
+                // In some cases, it's very bad to continue. Something completely invalid has happened, fundamental assumptions are wrong. This should have been taken care of by the callers, so fail attach.
+                return;
             }
 
             // Now that we know which AttachmentPt, free up all objects on that attachment point except 'group'.
-            if (appendMode == false)
+            if (!appendMode)
                 DetachSingleAttachmentPointToInv(AttachmentPt, remoteClient, group);
 
             // Saves and gets assetID
@@ -935,7 +936,6 @@ namespace OpenSim.Region.Framework.Scenes
             {
                 group.IsTempAttachment = false;
             }
-
 
             group.AttachToAgent(remoteClient.AgentId, AttachmentPt, silent);
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -4780,6 +4780,13 @@ namespace OpenSim.Region.Framework.Scenes
             if (AttachmentPt == 0)
                 AttachmentPt = restored;    // wear on previous att point
 
+            if (this.RootPart.IsLindenPlant())
+            {
+                m_log.WarnFormat("[SCENE]: Refusing attempt to wear Linden plant '{0}' owned by {1}.", this.Name, this.OwnerID);
+                shouldTaint = false;
+                return false;
+            }
+
             if (AttachmentPt > SceneObjectPart.MAX_ATTACHMENT)
             {
                 m_log.WarnFormat("[SCENE] Invalid attachment point ({0}) for '{1}'.", AttachmentPt, this.Name);

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -317,6 +317,12 @@ namespace OpenSim.Region.Framework.Scenes
                 return (att >= MIN_HUD) && (att <= MAX_HUD);
             }
         }
+        public bool IsLindenPlant()
+        {
+            return (m_shape.PCode == (byte)PCode.Grass)
+                || (m_shape.PCode == (byte)PCode.Tree)
+                || (m_shape.PCode == (byte)PCode.NewTree);
+        }
 
         [XmlIgnore]
         public UUID AttachedAvatar


### PR DESCRIPTION
Several fixes while I was in there looking at Linden plants:
- Fixes `llGetObjectDetails` calls with `OBJECT_PATHFINDING_TYPE` to return `OPT_OTHER` for Linden plants.
- Fixed handling of attempts to wear Linden plants that were rezzed in a region.
- Improved error handling related to attaching objects (may even fix ghost HUD issue) and objects ending up at 0,0,0
