### PR TITLE
Fix the name of the new water texture

### DIFF
--- a/bin/assets/TexturesAssetSet/TexturesAssetSet.xml
+++ b/bin/assets/TexturesAssetSet/TexturesAssetSet.xml
@@ -838,7 +838,7 @@
     <Key Name="assetID" Value="43c32285-d658-1793-c123-bf86315de055"/>
     <Key Name="name" Value="Water"/>
     <Key Name="assetType" Value="0" />
-    <Key Name="fileName" Value="43c32285-d658-1793-c123-bf86315de055.jp2" />
+    <Key Name="fileName" Value="43c32285-d658-1793-c123-bf86315de055.j2c" />
   </Section>
   
   <!-- 


### PR DESCRIPTION
- This fixes the error reported after PR https://github.com/HalcyonGrid/halcyon/pull/125

NOTE: The texture is meant for the viewer in the event that transparent water is disabled in viewer graphics preferences.  I will be checking further to see if it is the correct water texture however it is referenced via the viewer.