### PR TITLE
Fix for the 26 items max task inventory bug. 

### DIFF
--- a/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
@@ -995,7 +995,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public class InventoryStringBuilder
         {
-            public StringBuilder BuildString = new StringBuilder();
+            public StringBuilder BuildString = new StringBuilder(1024);
 
             public InventoryStringBuilder(UUID folderID, UUID parentID)
             {
@@ -1008,12 +1008,12 @@ namespace OpenSim.Region.Framework.Scenes
 
             public void AddEnd()
             {
-                BuildString.Append("\t}");  // no terminating \n
+                BuildString.Append("\n\t}");  // add \n before \t}
             }
 
             public void AddItemStart()
             {
-                BuildString.Append("\tinv_item\t0\n");
+                BuildString.Append("\tinv_item\t0\n\t{\n");
                 AddSectionStart();
             }
 


### PR DESCRIPTION
Credit to Hyacinth Jean for sleuthing the fix and Jim Tarber for supplying it to Skye-Grid.  This should still be tested before integration into a release but as you can see it's a fairly straightforward fix.